### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/org/shredzone/acme4j/AcmeUtils.java
+++ b/src/main/java/org/shredzone/acme4j/AcmeUtils.java
@@ -36,6 +36,11 @@ import java.util.stream.Stream;
 
 public class AcmeUtils {
 
+    private static void validateHashKey(String hashKey) {
+        if (hashKey.contains("..") || hashKey.contains("/") || hashKey.contains("\\")) {
+            throw new IllegalArgumentException("Invalid hashKey");
+        }
+    }
     private static final Logger LOGGER = LoggerFactory.getLogger(AcmeUtils.class);
 
     private AcmeUtils(){
@@ -313,6 +318,7 @@ public class AcmeUtils {
     }
 
     public static JsonNode readCertificate(String hashKey) throws IOException {
+        validateHashKey(hashKey);
         ObjectNode on =  mapper.createObjectNode();
         String certificatePath = CERTS_PATH+File.separator+hashKey;
         on.put("id",hashKey);
@@ -320,9 +326,9 @@ public class AcmeUtils {
         on.put("certificate", Files.readString(Path.of(certificatePath+"/server.crt")));
         return on;
 
-
     }
     public static void saveCertificate(String hashKey,Order order,AcmeContext context){
+        validateHashKey(hashKey);
         String certificatePath = CERTS_PATH+File.separator+hashKey;
         File f = new File(certificatePath);
         if(!f.exists())


### PR DESCRIPTION
Potential fix for [https://github.com/dhaneeshtb/scaleguard/security/code-scanning/22](https://github.com/dhaneeshtb/scaleguard/security/code-scanning/22)

To fix the problem, we need to validate the `hashKey` before using it to construct file paths. We should ensure that the `hashKey` does not contain any path separators or sequences that could lead to directory traversal. This can be done by checking for the presence of "..", "/", and "\\" in the `hashKey` and rejecting it if any are found.

The best way to fix the problem without changing existing functionality is to add a validation method that checks the `hashKey` and call this method before constructing file paths in the `saveCertificate` and `readCertificate` methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
